### PR TITLE
Look for one of two different session cookie names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ An example of the value for the `Cookie` header for local testing would be:
 api_session=MU8xTVEvSFpNOUg1bmZocTZIcytRY091eWE5S3pNKzVtdEF2alVUTiswN2l0N0JTcHJodE5QZUl6aWlNbWg3ZENsZW0yRFFhc0xYMWp6UFJLc0t3bXBiRmdHWjNVMFBvWitqa3BGMG0zZ281QTNZSEVUaDErY3E4bDlNVHNYcG1TcnVZaXZaQ1dvNDNJRW1MLys3TjlKbUxpaW0rTE1xWVZvZnppcVF6MVZBRTZtZTc5QVhqVklHR2FSSmo3bTUyN1ZycTF0QmloeHVpVWgwbHhWWWViK0dKWTQ3K1dBbHFWRU40NmptMjladXN2SHBHckMveXkxOVZ3L2Jab1llZmFyeWNRUEpRaVY5cW1nUjdmSXpXZ3diajZXYStta2w5SVp6bFpmdGJ4ODlVSVF5Y2FidWZ4Q2cwMllKRE44bUNGbUR2MTFOZXl1NkdqcEtuWGNTVnpjcCtWY25GTHIvNUpKeUdGdDZZWVY0PS0ta0MyNncrb2pxNFM4S2xNRTc1VkZkUT09--068924b4abb306a7eb1b0138477b740c70f1dc68; vagov_session_dev=fzdVGr0CT1FgDv_SxjWQty1LfIF5Vgcmj9OgWC-VFx6Liyt8YkrIgjCr6NFFx__Snv9DRG61DNIRwjot-JpA6sT2S1xP17YgD4mmKI9r5XX8x4lzZp0U5LtoBBfSHRqlOlWQmVFbIEc4aQP8kxhv7o91Duu997raWNyKizUmCoVJ-H_wVWCQI-tdn48jPyNT0Wi-Y-Cq-EbFtcfDDQX0LVqpTlTaIPd_QgjuY9v1Kn96p0EcBQwJzjFv28hv9KEx
 ```
 
-Because valid values change whenever you sign in, updating the `Cookie` header is a pain; you need to copy the current cookie values from the web inspector and paste them into the long string shown above. This is slow, tedious, and error-prone. Mostly slow. And oh so tedious.
+> NOTE: The name of the second cookie is no longer stable. For example, when testing locally the cookie name might be `vagov_saml_request_localhost` instead of `vagov_session_dev`. This only makes it more tedious to get the cookie names manually, making this Chrome extension even more useful.
+
+Because valid cookie values change whenever you sign in, updating the `Cookie` header is a pain; you need to copy the current cookie values from the web inspector and paste them into the long string shown above. This is slow, tedious, and error-prone. Mostly slow. And oh so tedious.
 
 ## The Solution
 
-This Chrome extension aims to make it easier to update the `Cookie` header in a REST client like Postman or Paw. Once you are signed into VA.gov (in either the prod, staging, dev, or local environments), click on the extension's icon. This will copy the current cookie values to your clipboard.
+This Chrome extension aims to make it easier to update the `Cookie` header in a REST client like Postman or Paw. Once you are signed into VA.gov (in either the prod, staging, dev, or local environments), click on the extension's icon and then on the `Copy VA user cookies` button. This will copy the current cookie values to your clipboard.
 
 ![Copy cookies with Chrome extension](./docs/copy-cookies.gif)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Copy VA.gov session cookies",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Copies the api and vagov session cookies so you can easily paste them into a REST client header named `Cookie`",
   "permissions": [
     "tabs",

--- a/popup.js
+++ b/popup.js
@@ -1,42 +1,48 @@
 const copyCookiesButton = document.querySelector('button');
-const API_SESSION_COOKIE_NAME = 'api_session';
-let VAGOV_SESSION_COOKIE_NAME;
+const API_COOKIE_NAME = 'api_session';
+let SESSION_COOKIE_NAME;
 
 const DOMAINS = {
   LOCAL: 'localhost',
-  STAGING: 'staging.va.gov',
   DEV: 'dev.va.gov',
+  STAGING: 'staging.va.gov',
   PROD: 'www.va.gov',
 };
 
 // The cookie domains (where to get the cookies from)
 const domainToCookieDomainMap = {
   [DOMAINS.LOCAL]: 'localhost',
-  [DOMAINS.STAGING]: '.va.gov',
   [DOMAINS.DEV]: '.va.gov',
+  [DOMAINS.STAGING]: '.va.gov',
   [DOMAINS.PROD]: '.va.gov',
 };
 // The domains of the API session cookie
 const apiSessionCookieDomains = {
   [DOMAINS.LOCAL]: 'localhost',
-  [DOMAINS.STAGING]: 'staging-api.va.gov',
   [DOMAINS.DEV]: 'dev-api.va.gov',
+  [DOMAINS.STAGING]: 'staging-api.va.gov',
   [DOMAINS.PROD]: 'api.va.gov',
 };
 // The domains of the VAGOV session cookie
 const vagovSessionCookieDomains = {
   [DOMAINS.LOCAL]: 'localhost',
-  [DOMAINS.STAGING]: '.va.gov',
   [DOMAINS.DEV]: '.va.gov',
+  [DOMAINS.STAGING]: '.va.gov',
   [DOMAINS.PROD]: '.va.gov',
 };
-// The names of the VAGOV session cookie; we look for a different cookie
-// depending on which domain/environment we are in
+// The possible names of the VAGOV session cookie. The cookie name will depend
+// on which environment we are running in. Also, for each environment, the
+// cookie name might vary based on the user's auth method. The cookie name for
+// each environment used to be stable, but the cookie names have changed. For
+// example, when testing locally the cookie name used to be 'vagov_session_dev'
+// but it is now 'vagov_saml_request_localhost'. I'm not sure if that change
+// affects all users or just some, so we are using an array of possible cookie
+// names and will use the first cookie that has a value.
 const domainToVAGOVSessionCookieMap = {
-  [DOMAINS.LOCAL]: 'vagov_session_dev',
-  [DOMAINS.STAGING]: 'vagov_session_staging',
-  [DOMAINS.DEV]: 'vagov_session_dev',
-  [DOMAINS.PROD]: 'vagov_session',
+  [DOMAINS.LOCAL]: ['vagov_session_dev', 'vagov_saml_request_localhost'],
+  [DOMAINS.DEV]: ['vagov_session_dev', 'vagov_saml_request_dev'],
+  [DOMAINS.STAGING]: ['vagov_session_staging', 'vagov_saml_request_staging'],
+  [DOMAINS.PROD]: ['vagov_session', 'vagov_saml_request_prod'],
 };
 
 function logIt(val) {
@@ -47,21 +53,21 @@ function logIt(val) {
  * Takes the two cookie values and creates a string that will serve as a value
  * for the 'Cookie' header in your REST client
  *
- * @param {string} cookie1 the value of the api_session cookie
- * @param {string} cookie2 the value of the vagov_session_dev cookie
+ * @param {string} cookie1 the value of the api cookie
+ * @param {string} cookie2 the value of the session cookie
  */
 function buildCookieHeaderValue(cookie1, cookie2) {
   if (
     !cookie1 ||
     !cookie2 ||
-    typeof cookie1 != 'string' ||
-    typeof cookie2 != 'string'
+    typeof cookie1 !== 'string' ||
+    typeof cookie2 !== 'string'
   ) {
     alert('Please pass two strings to `buildCookieHeaderValue`');
     window.close();
     return;
   }
-  return `${API_SESSION_COOKIE_NAME}=${cookie1}; ${VAGOV_SESSION_COOKIE_NAME}=${cookie2}`;
+  return `${API_COOKIE_NAME}=${cookie1}; ${SESSION_COOKIE_NAME}=${cookie2}`;
 }
 
 function copyToClipboard(string) {
@@ -89,27 +95,36 @@ function getDomainFromURL(url) {
 
 function getCookies(url) {
   const domain = getDomainFromURL(url);
-  VAGOV_SESSION_COOKIE_NAME = domainToVAGOVSessionCookieMap[domain];
+  const sessionCookieNames = domainToVAGOVSessionCookieMap[domain];
   chrome.cookies.getAll(
     { domain: domainToCookieDomainMap[domain] },
     cookies => {
       let apiSessionCookie = cookies.find(
         cookie =>
-          cookie.name === API_SESSION_COOKIE_NAME &&
+          cookie.name === API_COOKIE_NAME &&
           cookie.domain === apiSessionCookieDomains[domain],
       );
-      let vagovSessionCookie = cookies.find(
-        cookie =>
-          cookie.name === VAGOV_SESSION_COOKIE_NAME &&
-          cookie.domain === vagovSessionCookieDomains[domain],
-      );
+      let vagovSessionCookie;
+      // try getting the session cookie from all the potential cookie names
+      sessionCookieNames.forEach((cookieName) => {
+        if (!vagovSessionCookie) {
+          vagovSessionCookie = cookies.find(
+            (cookie) =>
+              cookie.name === cookieName &&
+              cookie.domain === vagovSessionCookieDomains[domain],
+          )
+          if (!!vagovSessionCookie) {
+            SESSION_COOKIE_NAME = cookieName
+          }
+        }
+      })
       if (!apiSessionCookie) {
-        alert(`Unable to find the '${API_SESSION_COOKIE_NAME}' cookie!`);
+        alert(`Unable to find the '${API_COOKIE_NAME}' cookie!`);
         window.close();
         return;
       }
       if (!vagovSessionCookie) {
-        alert(`Unable to find the '${VAGOV_SESSION_COOKIE_NAME}' cookie!`);
+        alert(`Unable to find any of the '${SESSION_COOKIE_NAME}' cookies!`);
         window.close();
         return;
       }


### PR DESCRIPTION
The name of the session cookie changed at some point. This PR updates
the cookie-fetching logic to look for one of two different cookie
named. I'm not sure if the cookie names have changed across the board or
if the names have only changed for some users as part of the SSOe
rollout.